### PR TITLE
1.7.1: Fix spelling of Sansculotides.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Change Log
 ==========
 
+1.7.1  *(2017-09-18)*
+--------------------
+* Fixed spelling of Sansculotides, to match the spelling in the [original decree] (http://1789-1799.blogspot.fr/2011/12/le-calendrier-republicain-14.html)
+
 1.7.0  *(2017-07-33)*
 --------------------
 * Added a a function `getDate()` to convert from a `FrenchRevolutionaryCalendarDate` to a `GregorianCalendar`.

--- a/README.md
+++ b/README.md
@@ -17,14 +17,14 @@ Maven:
 <dependency>
   <groupId>ca.rmen</groupId>
   <artifactId>lib-french-revolutionary-calendar</artifactId>
-  <version>1.7.0</version>
+  <version>1.7.1</version>
   <type>pom</type>
 </dependency>
 ```
 
 Gradle:
 ```
-compile 'ca.rmen:lib-french-revolutionary-calendar:1.7.0'
+compile 'ca.rmen:lib-french-revolutionary-calendar:1.7.1'
 
 ```
 
@@ -49,7 +49,7 @@ A command-line program is available.
 
 Build it with: `mvn clean package`
 
-Run it with `java -jar ./cli/target/french-revolutionary-calendar-cli-1.7.0.jar`
+Run it with `java -jar ./cli/target/french-revolutionary-calendar-cli-1.7.1.jar`
 
 With no arguments, it will print out a usage text.
 
@@ -57,12 +57,12 @@ Examples:
 
 Display the current time in the French Revolutionary Calendar:
 ```shell
-$java -jar ./cli/target/french-revolutionary-calendar-cli-1.7.0.jar now
+$java -jar ./cli/target/french-revolutionary-calendar-cli-1.7.1.jar now
 Quartidi, 04-Thermidor-225, 8:70:99, The plant:Ryegrass
 ```
 Display an arbitrary date in the French Revolutionary Calendar:
 ```
-$ java -jar ./cli/target/french-revolutionary-calendar-cli-1.7.0.jar g2f 1998-06-10
+$ java -jar ./cli/target/french-revolutionary-calendar-cli-1.7.1.jar g2f 1998-06-10
 Parsing using format yyyy-MM-dd
 Duodi, 22-Prairial-206, 0:00:00, The plant:Camomile
 ```

--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>ca.rmen</groupId>
     <artifactId>parent</artifactId>
-    <version>1.7.0</version>
+    <version>1.7.1</version>
   </parent>
 
   <artifactId>french-revolutionary-calendar-cli</artifactId>

--- a/library/pom.xml
+++ b/library/pom.xml
@@ -9,12 +9,12 @@
   <parent>
     <groupId>ca.rmen</groupId>
     <artifactId>parent</artifactId>
-    <version>1.7.0</version>
+    <version>1.7.1</version>
   </parent>
 
   <artifactId>lib-french-revolutionary-calendar</artifactId>
   <packaging>jar</packaging>
-  <version>1.7.0</version>
+  <version>1.7.1</version>
   <name>lib-french-revolutionary-calendar</name>
   <url>http://rmen.ca</url>
 

--- a/library/src/main/kotlin/ca/rmen/lfrc/i18n/FrenchRevolutionaryCalendarLabelsCA.kt
+++ b/library/src/main/kotlin/ca/rmen/lfrc/i18n/FrenchRevolutionaryCalendarLabelsCA.kt
@@ -32,7 +32,7 @@ internal class FrenchRevolutionaryCalendarLabelsCA : FrenchRevolutionaryCalendar
     companion object {
 
         @JvmField
-        val MONTHS = arrayOf("Veremari", "Brumari", "Frimari", "Nivós", "Pluviós", "Ventós", "Germinal", "Floreal", "Pradal", "Messidor", "Termidor", "Fructidor", "Sanculotides")
+        val MONTHS = arrayOf("Veremari", "Brumari", "Frimari", "Nivós", "Pluviós", "Ventós", "Germinal", "Floreal", "Pradal", "Messidor", "Termidor", "Fructidor", "Sansculotides")
 
         @JvmField
         val DAY_OF_YEAR = arrayOf(
@@ -60,7 +60,7 @@ internal class FrenchRevolutionaryCalendarLabelsCA : FrenchRevolutionaryCalendar
                 arrayOf("Espelta", "Herba blenera", "Meló", "Zitzània", "Marrà", "Cua de cavall", "Artemísia", "Càrtam", "Móra", "Regadora", "Panical", "Salicorn", "Albercoc", "Alfàbrega", "Ovella", "Malví", "Lli", "Ametlla", "Genciana", "Resclosa", "Carlina", "Tàpera", "Llentia", "ínula", "Llúdria", "Murta", "Colza", "Tramús", "Cotó", "Molí"),
                 // Fructidor
                 arrayOf("Pruna", "Mill", "Pet de llop", "Ordi de dues carreres", "Salmó", "Nard", "Ordi de sis carreres", "Baladre", "Regalèssia", "Escala", "Síndria", "Fonoll", "Coralet", "Nou", "Truita de riu", "Llimona", "Cardó", "Rhamnus sp.", "Tagetes sp.", "Cove", "Englantina", "Avellana", "Llúpol", "Sorgo", "Cranc de riu", "Taronja agre", "Vara d'or", "Blat de moro", "Castanya", "Cistell"),
-                // Sanculotides
+                // Sansculotides
                 arrayOf("Virtut", "Geni", "Treball", "Opinió", "Recompenses", "Revolució"))
 
         @JvmField

--- a/library/src/main/kotlin/ca/rmen/lfrc/i18n/FrenchRevolutionaryCalendarLabelsDE.kt
+++ b/library/src/main/kotlin/ca/rmen/lfrc/i18n/FrenchRevolutionaryCalendarLabelsDE.kt
@@ -63,7 +63,7 @@ internal class FrenchRevolutionaryCalendarLabelsDE : FrenchRevolutionaryCalendar
                 // Fructidor
                 arrayOf("Pflaume", "Hirse", "Stäubling", "Futtergerste", "Lachs", "Tuberose", "Wintergerste", "Hundswürger", "Lakritze", "Leiter", "Wassermelone", "Fenchel", "Berberitze", "Walnuss", "Forelle", "Zitrone", "Karde", "Kreuzdorn", "Studentenblume", "Tragkorb", "Heckenrose", "Haselnuss", "Hopfen", "Sorghum", "Krebs", "Pomeranze", "Goldraute", "Mais", "Eßkastanie", "Korb"),
 
-                // Sanculotides
+                // Sansculotides
                 arrayOf("Tugenden", "Geistes", "Arbeit", "Meinung", "Belohnungen", "Revolution"))
 
         @JvmField

--- a/library/src/main/kotlin/ca/rmen/lfrc/i18n/FrenchRevolutionaryCalendarLabelsEN.kt
+++ b/library/src/main/kotlin/ca/rmen/lfrc/i18n/FrenchRevolutionaryCalendarLabelsEN.kt
@@ -57,7 +57,7 @@ internal class FrenchRevolutionaryCalendarLabelsEN : FrenchRevolutionaryCalendar
                 arrayOf("Spelt", "Common Mullein", "Melon", "Ryegrass", "Ram", "Horsetail", "Mugwort", "Safflower", "Blackberry", "Watering Can", "Switchgrass", "Common Glasswort", "Apricot", "Basil", "Ewe", "Marshmallow", "Flax", "Almond", "Gentian", "Lock", "Carline thistle", "Caper", "Lentil", "Inula", "Otter", "Myrtle", "Rapeseed", "Lupin", "Cotton", "Mill"),
                 // Fructidor
                 arrayOf("Plum", "Millet", "Puffball", "Six-row Barley", "Salmon", "Tuberose", "Winter Barley", "Apocynum", "Liquorice", "Ladder", "Watermelon", "Fennel", "Barberry", "Walnut", "Trout", "Lemon", "Teasel", "Buckthorn", "Mexican Marigold", "Harvesting basket", "Wild Rose", "Hazelnut", "Hops", "Sorghum", "Crayfish", "Bitter Orange", "Goldenrod", "Maize or Corn", "Sweet Chestnut", "Pack Basket"),
-                // Sanculotides
+                // Sansculotides
                 arrayOf("Virtue", "Talent", "Labor", "Convictions", "Honors", "Revolution"))
 
         @JvmField

--- a/library/src/main/kotlin/ca/rmen/lfrc/i18n/FrenchRevolutionaryCalendarLabelsES.kt
+++ b/library/src/main/kotlin/ca/rmen/lfrc/i18n/FrenchRevolutionaryCalendarLabelsES.kt
@@ -32,7 +32,7 @@ internal class FrenchRevolutionaryCalendarLabelsES : FrenchRevolutionaryCalendar
     companion object {
 
         @JvmField
-        val MONTHS = arrayOf("Vendimiario", "Brumario", "Frimario", "Nivoso", "Pluvioso", "Ventoso", "Germinal", "Floreal", "Pradial", "Mesidor", "Termidor", "Fructidor", "Sanculotides")
+        val MONTHS = arrayOf("Vendimiario", "Brumario", "Frimario", "Nivoso", "Pluvioso", "Ventoso", "Germinal", "Floreal", "Pradial", "Mesidor", "Termidor", "Fructidor", "Sansculotides")
 
         @JvmField
         val DAY_OF_YEAR = arrayOf(
@@ -62,7 +62,7 @@ internal class FrenchRevolutionaryCalendarLabelsES : FrenchRevolutionaryCalendar
                 // Fructidor
                 arrayOf("Ciruela", "Mijo", "Soplo de lobo", "Cebada", "Salmón", "Nardo", "Cebada", "Apocynaceae", "Regaliz", "Escala", "Sandía", "Hinojo", "Berberis", "Nuez", "Trucha", "Limón", "Cardencha", "Espino cerval", "Clavelón", "Cesto", "Escaramujo", "Avellana", "Lúpulo", "Sorgo", "Cangrejo de río", "Naranja amarga", "Vara de oro", "Maíz", "Castaña", "Cesta"),
 
-                // Sanculotides
+                // Sansculotides
                 arrayOf("Virtud", "Talento", "Trabajo", "Opinión", "Recompensas", "Revolución"))
 
         @JvmField

--- a/library/src/main/kotlin/ca/rmen/lfrc/i18n/FrenchRevolutionaryCalendarLabelsFR.kt
+++ b/library/src/main/kotlin/ca/rmen/lfrc/i18n/FrenchRevolutionaryCalendarLabelsFR.kt
@@ -34,7 +34,7 @@ internal class FrenchRevolutionaryCalendarLabelsFR : FrenchRevolutionaryCalendar
         @JvmField
         val WEEKDAYS = arrayOf("Primidi", "Duodi", "Tridi", "Quartidi", "Quintidi", "Sextidi", "Septidi", "Octidi", "Nonidi", "Décadi")
         @JvmField
-        val MONTHS = arrayOf("Vendémiaire", "Brumaire", "Frimaire", "Nivôse", "Pluviôse", "Ventôse", "Germinal", "Floréal", "Prairial", "Messidor", "Thermidor", "Fructidor", "Sanculotides")
+        val MONTHS = arrayOf("Vendémiaire", "Brumaire", "Frimaire", "Nivôse", "Pluviôse", "Ventôse", "Germinal", "Floréal", "Prairial", "Messidor", "Thermidor", "Fructidor", "Sansculotides")
 
         @JvmField
         val DAY_OF_YEAR = arrayOf(
@@ -62,7 +62,7 @@ internal class FrenchRevolutionaryCalendarLabelsFR : FrenchRevolutionaryCalendar
                 arrayOf("Épeautre", "Bouillon blanc", "Melon", "Ivraie", "Bélier", "Prêle", "Armoise", "Carthame", "Mûre", "Arrosoir", "Panic", "Salicorne", "Abricot", "Basilic", "Brebis", "Guimauve", "Lin", "Amande", "Gentiane", "Écluse", "Carline", "Câprier", "Lentille", "Aunée", "Loutre", "Myrte", "Colza", "Lupin", "Coton", "Moulin"),
                 // Fructidor
                 arrayOf("Prune", "Millet", "Lycoperdon", "Escourgeon", "Saumon", "Tubéreuse", "Sucrion", "Apocyn", "Réglisse", "Échelle", "Pastèque", "Fenouil", "Épine vinette", "Noix", "Truite", "Citron", "Cardère", "Nerprun", "Tagette", "Hotte", "Églantier", "Noisette", "Houblon", "Sorgho", "Écrevisse", "Bigarade", "Verge d'or", "Maïs", "Marron", "Panier"),
-                // Sanculotides
+                // Sansculotides
                 arrayOf("Vertu", "Génie", "Travail", "Opinion", "Récompenses", "Révolution"))
 
         @JvmField

--- a/library/src/main/kotlin/ca/rmen/lfrc/i18n/FrenchRevolutionaryCalendarLabelsIT.kt
+++ b/library/src/main/kotlin/ca/rmen/lfrc/i18n/FrenchRevolutionaryCalendarLabelsIT.kt
@@ -62,7 +62,7 @@ internal class FrenchRevolutionaryCalendarLabelsIT : FrenchRevolutionaryCalendar
                 arrayOf("Spelto", "Tasso barbasso", "Melone", "Loglio", "Ariete", "Equiseto", "Artemisia", "Cartamo", "Mora", "Annaffiatoio", "Eringio", "Salicornia", "Albicocca", "Basilico", "Pecora", "Altea", "Lino", "Mandorla", "Genziana", "Chiusa", "Carlina bianca", "Cappero", "Lenticchia", "Enula", "Lontra", "Mirto", "Colza", "Lupino", "Cotone", "Mulino"),
                 // Fructidor
                 arrayOf("Prugna", "Miglio", "Vescia", "Orzo maschio", "Salmone", "Tuberosa", "Orzo comune", "Apocino", "Liquirizia", "Scala", "Anguria", "Finocchio", "Crespino", "Noce", "Trota", "Limone", "Cardo", "Alaterno", "Garofano d'India", "Gerla", "Rosa canina", "Nocciola", "Luppolo", "Sorgo", "Gambero", "Arancio amaro", "Verga d'oro", "Granoturco", "Castagna", "Cesta"),
-                // Sanculotides
+                // Sansculotides
                 arrayOf("Virtù", "Genio", "Lavoro", "Opinione", "Ricompense", "Rivoluzione"))
 
         @JvmField

--- a/library/src/test/java/ca/rmen/lfrc/FrenchRevolutionaryCalendarEquinoxTest.java
+++ b/library/src/test/java/ca/rmen/lfrc/FrenchRevolutionaryCalendarEquinoxTest.java
@@ -48,17 +48,17 @@ public class FrenchRevolutionaryCalendarEquinoxTest extends FrenchRevolutionaryC
 
     @Test
     public void testFrenchDate7() throws Exception {
-        validateDates("1792-09-21", "0-13-05", "Quintidi", "Sanculotides", "Récompenses", "Honors", DailyObjectType.CONCEPT, 1);
+        validateDates("1792-09-21", "0-13-05", "Quintidi", "Sansculotides", "Récompenses", "Honors", DailyObjectType.CONCEPT, 1);
     }
 
     @Test
     public void testFrenchDate8() throws Exception {
-        validateDates("1791-09-21", "-1-13-05", "Quintidi", "Sanculotides", "Récompenses", "Honors", DailyObjectType.CONCEPT, 1);
+        validateDates("1791-09-21", "-1-13-05", "Quintidi", "Sansculotides", "Récompenses", "Honors", DailyObjectType.CONCEPT, 1);
     }
 
     @Test
     public void testFrenchDate9() throws Exception {
-        validateDates("1791-09-22", "-1-13-06", "Sextidi", "Sanculotides", "Révolution", "Revolution", DailyObjectType.CONCEPT, 1);
+        validateDates("1791-09-22", "-1-13-06", "Sextidi", "Sansculotides", "Révolution", "Revolution", DailyObjectType.CONCEPT, 1);
     }
 
     @Test

--- a/library/src/test/java/ca/rmen/lfrc/FrenchRevolutionaryCalendarRommeTest.java
+++ b/library/src/test/java/ca/rmen/lfrc/FrenchRevolutionaryCalendarRommeTest.java
@@ -58,12 +58,12 @@ public class FrenchRevolutionaryCalendarRommeTest extends FrenchRevolutionaryCal
 
     @Test
     public void testFrenchDate7() throws Exception {
-        validateDates("1792-09-21", "0-13-06", "Sextidi", "Sanculotides", "Révolution", "Revolution", DailyObjectType.CONCEPT, 1);
+        validateDates("1792-09-21", "0-13-06", "Sextidi", "Sansculotides", "Révolution", "Revolution", DailyObjectType.CONCEPT, 1);
     }
 
     @Test
     public void testFrenchDate8() throws Exception {
-        validateDates("1791-09-21", "-1-13-05", "Quintidi", "Sanculotides", "Récompenses", "Honors", DailyObjectType.CONCEPT, 1);
+        validateDates("1791-09-21", "-1-13-05", "Quintidi", "Sansculotides", "Récompenses", "Honors", DailyObjectType.CONCEPT, 1);
     }
 
     @Test

--- a/library/src/test/java/ca/rmen/lfrc/FrenchRevolutionaryCalendarVonMadlerTest.java
+++ b/library/src/test/java/ca/rmen/lfrc/FrenchRevolutionaryCalendarVonMadlerTest.java
@@ -214,7 +214,7 @@ public class FrenchRevolutionaryCalendarVonMadlerTest extends FrenchRevolutionar
 
     @Test
     public void testFrenchDate19201921() throws Exception {
-        validateDates("1920-09-22", "128-13-05", "Quintidi", "Sanculotides", "Récompenses", "Honors", DailyObjectType.CONCEPT, 1);
+        validateDates("1920-09-22", "128-13-05", "Quintidi", "Sansculotides", "Récompenses", "Honors", DailyObjectType.CONCEPT, 1);
         validateDates("1920-09-23", "129-01-01", "Primidi", "Vendémiaire", "Raisin", "Grape", DailyObjectType.PLANT, 1);
         validateDates("1920-10-23", "129-02-01", "Primidi", "Brumaire", "Pomme", "Apple", DailyObjectType.PLANT, 1);
         validateDates("1920-10-24", "129-02-02", "Duodi", "Brumaire", "Céleri", "Celery", DailyObjectType.PLANT, 1);
@@ -253,8 +253,8 @@ public class FrenchRevolutionaryCalendarVonMadlerTest extends FrenchRevolutionar
         validateDates("1939-04-16", "147-07-26", "Sextidi", "Germinal", "Lilas", "Lilac", DailyObjectType.PLANT, 3);
         validateDates("1939-04-20", "147-07-30", "Décadi", "Germinal", "Greffoir", "Knife", DailyObjectType.TOOL, 3);
         validateDates("1939-04-21", "147-08-01", "Primidi", "Floréal", "Rose", "Rose", DailyObjectType.PLANT, 1);
-        validateDates("1939-09-18", "147-13-01", "Primidi", "Sanculotides", "Vertu", "Virtue", DailyObjectType.CONCEPT, 1);
-        validateDates("1939-09-22", "147-13-05", "Quintidi", "Sanculotides", "Récompenses", "Honors", DailyObjectType.CONCEPT, 1);
+        validateDates("1939-09-18", "147-13-01", "Primidi", "Sansculotides", "Vertu", "Virtue", DailyObjectType.CONCEPT, 1);
+        validateDates("1939-09-22", "147-13-05", "Quintidi", "Sansculotides", "Récompenses", "Honors", DailyObjectType.CONCEPT, 1);
         validateDates("1939-09-23", "148-01-01", "Primidi", "Vendémiaire", "Raisin", "Grape", DailyObjectType.PLANT, 1);
         validateDates("1939-10-23", "148-02-01", "Primidi", "Brumaire", "Pomme", "Apple", DailyObjectType.PLANT, 1);
         validateDates("1939-10-31", "148-02-09", "Nonidi", "Brumaire", "Alisier", "Chequer Tree", DailyObjectType.PLANT, 1);
@@ -319,8 +319,8 @@ public class FrenchRevolutionaryCalendarVonMadlerTest extends FrenchRevolutionar
     @Test
     public void testFrenchDate2016XXXX() throws Exception {
         validateDates("2016-08-18", "224-12-01", "Primidi", "Fructidor", "Prune", "Plum", DailyObjectType.PLANT, 1);
-        validateDates("2016-09-17", "224-13-01", "Primidi", "Sanculotides", "Vertu", "Virtue", DailyObjectType.CONCEPT, 1);
-        validateDates("2016-09-22", "224-13-06", "Sextidi", "Sanculotides", "Révolution", "Revolution", DailyObjectType.CONCEPT, 1);
+        validateDates("2016-09-17", "224-13-01", "Primidi", "Sansculotides", "Vertu", "Virtue", DailyObjectType.CONCEPT, 1);
+        validateDates("2016-09-22", "224-13-06", "Sextidi", "Sansculotides", "Révolution", "Revolution", DailyObjectType.CONCEPT, 1);
         validateDates("2016-09-24", "225-01-02", "Duodi", "Vendémiaire", "Safran", "Saffron", DailyObjectType.PLANT, 1);
         validateDates("2016-10-29", "225-02-07", "Septidi", "Brumaire", "Figue", "Common Fig", DailyObjectType.PLANT, 1);
         validateDates("2016-10-30", "225-02-08", "Octidi", "Brumaire", "Scorsonère", "Black Salsify", DailyObjectType.PLANT, 1);

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
   <groupId>ca.rmen</groupId>
   <artifactId>parent</artifactId>
   <packaging>pom</packaging>
-  <version>1.7.0</version>
+  <version>1.7.1</version>
   <name>french-revolutionary-calendar</name>
   <url>http://rmen.ca</url>
   <prerequisites>

--- a/publish.pom
+++ b/publish.pom
@@ -25,7 +25,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>ca.rmen</groupId>
 	<artifactId>lib-french-revolutionary-calendar</artifactId>
-	<version>1.7.0</version>
+	<version>1.7.1</version>
 	<packaging>jar</packaging>
 
 	<name>french-revolutionary-calendar</name>


### PR DESCRIPTION
Fixed spelling of Sansculotides, to match the spelling in the [original decree] (http://1789-1799.blogspot.fr/2011/12/le-calendrier-republicain-14.html)