### PR TITLE
Issue #17 - 1.8.1: Fix VonMadler test failures.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Change Log
 ==========
 
+1.8.1  *(2018-04-01)*
+--------------------
+* Fixed VonMadler calculation errors in time zones other than Paris.
+
 1.8.0  *(2017-09-30)*
 --------------------
 * Added Basque translations contributed by Aitor Beriain.

--- a/README.md
+++ b/README.md
@@ -17,14 +17,14 @@ Maven:
 <dependency>
   <groupId>ca.rmen</groupId>
   <artifactId>lib-french-revolutionary-calendar</artifactId>
-  <version>1.8.0</version>
+  <version>1.8.1</version>
   <type>pom</type>
 </dependency>
 ```
 
 Gradle:
 ```
-compile 'ca.rmen:lib-french-revolutionary-calendar:1.8.0'
+compile 'ca.rmen:lib-french-revolutionary-calendar:1.8.1'
 
 ```
 
@@ -49,7 +49,7 @@ A command-line program is available.
 
 Build it with: `mvn clean package`
 
-Run it with `java -jar ./cli/target/french-revolutionary-calendar-cli-1.8.0.jar`
+Run it with `java -jar ./cli/target/french-revolutionary-calendar-cli-1.8.1.jar`
 
 With no arguments, it will print out a usage text.
 
@@ -57,12 +57,12 @@ Examples:
 
 Display the current time in the French Revolutionary Calendar:
 ```shell
-$java -jar ./cli/target/french-revolutionary-calendar-cli-1.8.0.jar now
+$java -jar ./cli/target/french-revolutionary-calendar-cli-1.8.1.jar now
 Quartidi, 04-Thermidor-225, 8:70:99, The plant:Ryegrass
 ```
 Display an arbitrary date in the French Revolutionary Calendar:
 ```
-$ java -jar ./cli/target/french-revolutionary-calendar-cli-1.8.0.jar g2f 1998-06-10
+$ java -jar ./cli/target/french-revolutionary-calendar-cli-1.8.1.jar g2f 1998-06-10
 Parsing using format yyyy-MM-dd
 Duodi, 22-Prairial-206, 0:00:00, The plant:Camomile
 ```

--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>ca.rmen</groupId>
     <artifactId>parent</artifactId>
-    <version>1.8.0</version>
+    <version>1.8.1</version>
   </parent>
 
   <artifactId>french-revolutionary-calendar-cli</artifactId>

--- a/library/pom.xml
+++ b/library/pom.xml
@@ -9,12 +9,12 @@
   <parent>
     <groupId>ca.rmen</groupId>
     <artifactId>parent</artifactId>
-    <version>1.8.0</version>
+    <version>1.8.1</version>
   </parent>
 
   <artifactId>lib-french-revolutionary-calendar</artifactId>
   <packaging>jar</packaging>
-  <version>1.8.0</version>
+  <version>1.8.1</version>
   <name>lib-french-revolutionary-calendar</name>
   <url>http://rmen.ca</url>
 

--- a/library/src/main/kotlin/ca/rmen/lfrc/FrenchRevolutionaryCalendar.kt
+++ b/library/src/main/kotlin/ca/rmen/lfrc/FrenchRevolutionaryCalendar.kt
@@ -277,7 +277,7 @@ class FrenchRevolutionaryCalendar(
         // account the offset, a calculation like 8/5/1996 00:00:00 - 8/5/1796
         // 00:00:00 will not return 200 years, but 200 years - 1 hour, which is
         // not the desired result.
-        val numMillisSinceBeginningOfFrenchEra = gregorianDate.timeInMillis - frenchEraYearZero!!.timeInMillis + gregorianDate[Calendar.DST_OFFSET]
+        val numMillisSinceBeginningOfFrenchEra = gregorianDate.inUtc().timeInMillis - frenchEraYearZero!!.inUtc().timeInMillis
         // The number of days since day 0 of the French calendar (1791-09-23).
         val numDaysSinceFrenchEraBegin = (numMillisSinceBeginningOfFrenchEra / NUM_MILLISECONDS_IN_DAY).toInt()
 

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
   <groupId>ca.rmen</groupId>
   <artifactId>parent</artifactId>
   <packaging>pom</packaging>
-  <version>1.8.0</version>
+  <version>1.8.1</version>
   <name>french-revolutionary-calendar</name>
   <url>http://rmen.ca</url>
   <prerequisites>

--- a/publish.pom
+++ b/publish.pom
@@ -25,7 +25,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>ca.rmen</groupId>
 	<artifactId>lib-french-revolutionary-calendar</artifactId>
-	<version>1.8.0</version>
+	<version>1.8.1</version>
 	<packaging>jar</packaging>
 
 	<name>french-revolutionary-calendar</name>


### PR DESCRIPTION
When calculating the elapsed seconds between the given date and the `frenchEraYearZero`, instead of using the given date's `DST_OFFSET`, use the given date and `frenchEraYearZero` converted to the UTC timezone.