### PR TITLE
Issue #18 Fix romme calculations after 23:00 in some time zones.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Change Log
 1.8.1  *(2018-04-01)*
 --------------------
 * Fixed VonMadler calculation errors in time zones other than Paris.
+* Fixed Romme calculations after 23:00 in some time zones.
 
 1.8.0  *(2017-09-30)*
 --------------------

--- a/cli/src/test/java/ca/rmen/lfrc/cli/TestFrenchRevolutionaryCalendarCLI.java
+++ b/cli/src/test/java/ca/rmen/lfrc/cli/TestFrenchRevolutionaryCalendarCLI.java
@@ -42,7 +42,7 @@ public class TestFrenchRevolutionaryCalendarCLI {
         testG2f("2011-07-08 11:30:30 CEST", "Décadi, 20-Messidor-219, 4:79:51, The tool:Pen", CalculationMethod.ROMME);
         testG2f("2011-07-08 11:30:30 PDT", "Décadi, 20-Messidor-219, 4:79:51, The tool:Pen", CalculationMethod.ROMME);
         testG2f("2014-11-29 22:59:59 CET", "Nonidi, 09-Frimaire-223, 9:58:32, The plant:Juniper", CalculationMethod.ROMME);
-        testG2f("2014-11-29 23:59:59 CET", "Nonidi, 09-Frimaire-223, 9:99:98, The plant:Juniper", CalculationMethod.ROMME);
+        testG2f("2014-11-29 23:59:59 CET", "Nonidi, 09-Frimaire-223, 9:99:99, The plant:Juniper", CalculationMethod.ROMME);
         testG2f("2014-11-30 00:00:01 CET", "Décadi, 10-Frimaire-223, 0:00:01, The tool:Pickaxe", CalculationMethod.ROMME);
     }
 
@@ -71,7 +71,7 @@ public class TestFrenchRevolutionaryCalendarCLI {
     @Test
     public void testG2fDateAndTimeFullTimestamp() {
         testG2f("2014-11-29 22:59:59 CET", "Octidi, 08-Frimaire-223, 9:58:32, The plant:Honey", CalculationMethod.EQUINOX);
-        testG2f("2014-11-29 23:59:59 CET", "Octidi, 08-Frimaire-223, 9:99:98, The plant:Honey", CalculationMethod.EQUINOX);
+        testG2f("2014-11-29 23:59:59 CET", "Octidi, 08-Frimaire-223, 9:99:99, The plant:Honey", CalculationMethod.EQUINOX);
         testG2f("2014-11-30 00:00:01 CET", "Nonidi, 09-Frimaire-223, 0:00:01, The plant:Juniper", CalculationMethod.EQUINOX);
     }
 

--- a/library/pom.xml
+++ b/library/pom.xml
@@ -2,7 +2,7 @@
      xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <kotlin.version>1.1.2-4</kotlin.version>
+    <kotlin.version>1.2.30</kotlin.version>
   </properties>
   <modelVersion>4.0.0</modelVersion>
 

--- a/library/src/main/kotlin/ca/rmen/lfrc/FrenchRevolutionaryCalendar.kt
+++ b/library/src/main/kotlin/ca/rmen/lfrc/FrenchRevolutionaryCalendar.kt
@@ -25,6 +25,7 @@ import java.util.Calendar
 import java.util.GregorianCalendar
 import java.util.Locale
 import java.util.TimeZone
+import kotlin.math.roundToInt
 
 /**
 
@@ -413,7 +414,7 @@ class FrenchRevolutionaryCalendar(
             val dayFraction = ghour.toFloat() / 24 + gmin.toFloat() / 1440 + gsec.toFloat() / 86400
             val fhour = (dayFraction * 10).toInt()
             val fmin = ((dayFraction * 10 - fhour) * 100).toInt()
-            val fsec = ((dayFraction * 10 - (fhour + fmin.toFloat() / 100)) * 10000).toInt()
+            val fsec = ((dayFraction * 10 - (fhour + fmin.toFloat() / 100)) * 10000).roundToInt()
             return intArrayOf(fhour, fmin, fsec)
         }
 
@@ -432,7 +433,7 @@ class FrenchRevolutionaryCalendar(
             val dayFraction = fhour.toFloat() / 10 + fmin.toFloat() / 1000 + fsec.toFloat() / 100000
             val ghour = (dayFraction * 24).toInt()
             val gmin = ((dayFraction * 24 - ghour) * 60).toInt()
-            val gsec = ((dayFraction * 24 - (ghour + gmin.toFloat() / 60)) * 3600).toInt()
+            val gsec = ((dayFraction * 24 - (ghour + gmin.toFloat() / 60)) * 3600).roundToInt()
             return intArrayOf(ghour, gmin, gsec)
         }
 

--- a/library/src/main/kotlin/ca/rmen/lfrc/FrenchRevolutionaryCalendar.kt
+++ b/library/src/main/kotlin/ca/rmen/lfrc/FrenchRevolutionaryCalendar.kt
@@ -202,7 +202,7 @@ class FrenchRevolutionaryCalendar(
         // account the offset, a calculation like 8/5/1996 00:00:00 - 8/5/1796
         // 00:00:00 will not return 200 years, but 200 years - 1 hour, which is
         // not the desired result.
-        val numMillisSinceEndOfFrenchEra = gregorianDate.timeInMillis + gregorianDate[Calendar.DST_OFFSET] - frenchEraEnd!!.timeInMillis - frenchEraEnd!![Calendar.DST_OFFSET].toLong()
+        val numMillisSinceEndOfFrenchEra = gregorianDate.inUtc().timeInMillis - frenchEraEnd!!.inUtc().timeInMillis
 
         // The Romme method applies the same
         // rules (mostly) of the Gregorian calendar to the French calendar.
@@ -219,12 +219,13 @@ class FrenchRevolutionaryCalendar(
 
         // The end of the French calendar system was the beginning of the year
         // 20.
-        val fakeEndFrenchEraTimestamp = GregorianCalendar(2020, 0, 1).timeInMillis
+        val fakeEndFrenchEraTimestamp = createGregorianDateUtc(2020, 0, 1).timeInMillis
+
         // Add the elapsed time to the French date.
         val fakeFrenchTimestamp = fakeEndFrenchEraTimestamp + numMillisSinceEndOfFrenchEra
 
         // Create a calendar object for the French date
-        val fakeFrenchDate = Calendar.getInstance(gregorianDate.timeZone)
+        val fakeFrenchDate = Calendar.getInstance(utcTimeZone)
         fakeFrenchDate.timeInMillis = fakeFrenchTimestamp
 
         // Extract the year, and day in year from the French date.

--- a/library/src/test/java/ca/rmen/lfrc/FrenchRevolutionaryCalendarEquinoxTest.java
+++ b/library/src/test/java/ca/rmen/lfrc/FrenchRevolutionaryCalendarEquinoxTest.java
@@ -72,6 +72,6 @@ public class FrenchRevolutionaryCalendarEquinoxTest extends FrenchRevolutionaryC
 
     @Test
     public void testFrenchDateAndTime2() throws Exception {
-        validateDateAndTime("2014-11-29 23:59:59", "223-03-08 09:99:98", "Octidi", "Frimaire", "Miel", "Honey", DailyObjectType.PLANT, 1);
+        validateDateAndTime("2014-11-29 23:59:59", "223-03-08 09:99:99", "Octidi", "Frimaire", "Miel", "Honey", DailyObjectType.PLANT, 1);
     }
 }

--- a/library/src/test/java/ca/rmen/lfrc/FrenchRevolutionaryCalendarRommeTest.java
+++ b/library/src/test/java/ca/rmen/lfrc/FrenchRevolutionaryCalendarRommeTest.java
@@ -72,6 +72,13 @@ public class FrenchRevolutionaryCalendarRommeTest extends FrenchRevolutionaryCal
     }
 
     @Test
+    public void testIssue18() throws Exception {
+        validateDates("2018-01-28", "226-05-09", "Nonidi", "Pluviôse", "Peuplier", "Poplar Tree", DailyObjectType.PLANT, 1);
+        validateDateAndTime("2018-01-28 22:59:00", "226-05-09 09:57:64", "Nonidi", "Pluviôse", "Peuplier", "Poplar Tree", DailyObjectType.PLANT, 1);
+        validateDateAndTime("2018-01-28 23:00:00", "226-05-09 09:58:33", "Nonidi", "Pluviôse", "Peuplier", "Poplar Tree", DailyObjectType.PLANT, 1);
+    }
+
+    @Test
     public void testFrenchDate10() throws Exception {
         validateDates("2016-01-01", "224-04-12", "Duodi", "Nivôse", "Argile", "Clay", DailyObjectType.MINERAL, 2);
         validateDates("2016-01-20", "224-05-01", "Primidi", "Pluviôse", "Lauréole", "Spurge-laurel", DailyObjectType.PLANT, 1);


### PR DESCRIPTION
Instead of using `DST_OFFSET` in the local time zone, use Utc timestamps.